### PR TITLE
More Restrictive Public Suffix List Validation

### DIFF
--- a/src/main/scala/com/kodekutters/psl/PublicSuffixList.scala
+++ b/src/main/scala/com/kodekutters/psl/PublicSuffixList.scala
@@ -30,7 +30,7 @@ object PublicSuffixList {
       // the PSL file from the URL to the Public Suffix List (PSL).
       var sourceBuffer = Source.fromURL(new URL(properties.getString("psl.url"))) // implicit codec charset
       // parse the rules file into a list of rules and add the default rule to it
-      val rules = Parser().parse(sourceBuffer) :+ Rule.DEFAULT_RULE
+      val rules = Parser().parse(sourceBuffer)
       new PublicSuffixList(new RuleList(rules), printFlag)
     } catch {
       case e: Exception => println("exception caught: " + e); null

--- a/src/main/scala/com/kodekutters/psl/PublicSuffixList.scala
+++ b/src/main/scala/com/kodekutters/psl/PublicSuffixList.scala
@@ -30,7 +30,7 @@ object PublicSuffixList {
       // the PSL file from the URL to the Public Suffix List (PSL).
       var sourceBuffer = Source.fromURL(new URL(properties.getString("psl.url"))) // implicit codec charset
       // parse the rules file into a list of rules and add the default rule to it
-      val rules = Parser().parse(sourceBuffer)
+      val rules = Parser().parse(sourceBuffer) :+ Rule.DEFAULT_RULE
       new PublicSuffixList(new RuleList(rules), printFlag)
     } catch {
       case e: Exception => println("exception caught: " + e); null

--- a/src/main/scala/com/kodekutters/psl/Rule.scala
+++ b/src/main/scala/com/kodekutters/psl/Rule.scala
@@ -38,9 +38,9 @@ object Rule {
     *
     * @return true if the label matches the rule pattern
     */
-  private def isLabelMatch(pattern: String, label: String): Boolean = {
+  private def isLabelMatch(pattern: String, label: String, patternIndex: Integer): Boolean = {
     if (pattern == null || pattern.isEmpty || label == null || label.isEmpty) false
-    else if (pattern == Rule.WILDCARD) true
+    else if (pattern == Rule.WILDCARD && patternIndex > 0) true // Do not use the Wildcard rule for TLDs
     else pattern.equalsIgnoreCase(label)
   }
 
@@ -75,7 +75,7 @@ case class Rule(pattern: String, exceptionRule: Boolean) {
         val reversedMatchedLabels = new Array[String](reversedLabels.length)
         var matchOk = true
         for (i <- reversedLabels.indices) {
-          if (i < reversedDomainLabels.length && isLabelMatch(reversedLabels(i), reversedDomainLabels(i)))
+          if (i < reversedDomainLabels.length && isLabelMatch(reversedLabels(i), reversedDomainLabels(i), i))
             reversedMatchedLabels(i) = reversedDomainLabels(i)
           else
             matchOk = false


### PR DESCRIPTION
This pr disallows the use of the wildcard(*) rule at the TLD level. So that something like ("bad.bad") does not pass the PSL validation. 
