### PR TITLE
add full path to more simplest usage in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Very simple to use, see the **Example.scala** and **TestApp.scala**.
 
 From *Example.scala*:
 
-        val psl = PublicSuffixList()
+        val psl = com.kodekutters.psl.PublicSuffixList()
         println("the public suffix of \"www.example.net\" is: " + psl.publicSuffix("www.example.net").get)
         println("\"www.example.net\" is a public suffix: " + psl.isPublicSuffix("www.example.net"))
         println("\"www.example.net\" is registrable: " + psl.isRegistrable("www.example.net"))

--- a/src/main/scala/com/kodekutters/psl/Example.scala
+++ b/src/main/scala/com/kodekutters/psl/Example.scala
@@ -6,7 +6,7 @@ package com.kodekutters.psl
 object Example {
 
   def main(args: Array[String]) {
-    val psl = PublicSuffixList()
+    val psl = com.kodekutters.psl.PublicSuffixList()
     println("the public suffix of \"www.example.net\" is: " + psl.publicSuffix("www.example.net").get)
     println("\"www.example.net\" is a public suffix: " + psl.isPublicSuffix("www.example.net"))
     println("\"www.example.net\" is registrable: " + psl.isRegistrable("www.example.net"))


### PR DESCRIPTION
It more usefull for first touch in amm, for example